### PR TITLE
Fixed Pedestal Subtraction

### DIFF
--- a/include/tpglibs/AVXFixedPedestalSubtractProcessor.hpp
+++ b/include/tpglibs/AVXFixedPedestalSubtractProcessor.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file AVXFixedPedestalSubtractProcessor.hpp
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "tpglibs/AVXFactory.hpp"
+#include "tpglibs/AVXFrugalPedestalSubtractProcessor.hpp"
+
+#ifndef TPGLIBS_AVXFIXEDPEDESTALSUBTRACTPROCESSOR_HPP_
+#define TPGLIBS_AVXFIXEDPEDESTALSUBTRACTPROCESSOR_HPP_
+
+namespace tpglibs {
+
+class AVXFixedPedestalSubtractProcessor : public AVXFrugalPedestalSubtractProcessor {
+  protected:
+    uint16_t m_start_period{1000};
+    uint16_t m_num_time_steps{0};
+
+  public:
+    __m256i process(const __m256i& signal) override;
+    void configure(const nlohmann::json& config, const int16_t* plane_numbers) override;
+};
+
+} // namespace tpglibs
+
+#endif // TPGLIBS_AVXFIXEDPEDESTALSUBTRACTPROCESSOR_HPP_

--- a/include/tpglibs/AVXFrugalPedestalSubtractProcessor.hpp
+++ b/include/tpglibs/AVXFrugalPedestalSubtractProcessor.hpp
@@ -14,9 +14,10 @@
 namespace tpglibs {
 
 class AVXFrugalPedestalSubtractProcessor : public AVXProcessor {
-  __m256i m_pedestal = _mm256_setzero_si256();
-  __m256i m_accum = _mm256_setzero_si256();
-  int16_t m_accum_limit{10};
+  protected:
+    __m256i m_pedestal = _mm256_setzero_si256();
+    __m256i m_accum = _mm256_setzero_si256();
+    int16_t m_accum_limit{10};
 
   public:
     __m256i process(const __m256i& signal) override;

--- a/include/tpglibs/AVXFrugalPedestalSubtractProcessor.hpp
+++ b/include/tpglibs/AVXFrugalPedestalSubtractProcessor.hpp
@@ -15,7 +15,7 @@ namespace tpglibs {
 
 class AVXFrugalPedestalSubtractProcessor : public AVXProcessor {
   protected:
-    __m256i m_pedestal = _mm256_setzero_si256();
+    __m256i m_pedestal = _mm256_set1_epi16(0x4000);  // Set initial start to 14-bit max. Prevents garbage TPs at start.
     __m256i m_accum = _mm256_setzero_si256();
     int16_t m_accum_limit{10};
 

--- a/src/AVXFixedPedestalSubtractProcessor.cpp
+++ b/src/AVXFixedPedestalSubtractProcessor.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file AVXFixedPedestalSubtractProcessor.cpp
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "tpglibs/AVXFixedPedestalSubtractProcessor.hpp"
+
+namespace tpglibs {
+
+REGISTER_AVXPROCESSOR_CREATOR("AVXFixedPedestalSubtractProcessor", AVXFixedPedestalSubtractProcessor)
+
+void AVXFixedPedestalSubtractProcessor::configure(const nlohmann::json& config, const int16_t* plane_numbers) {
+  AVXFrugalPedestalSubtractProcessor::configure(config, plane_numbers);
+  m_start_period = config["start_period"];
+}
+
+__m256i AVXFixedPedestalSubtractProcessor::process(const __m256i& signal) {
+  if (m_num_time_steps < m_start_period) {
+    m_num_time_steps++;
+    return AVXFrugalPedestalSubtractProcessor::process(signal);
+  }
+  return AVXProcessor::process(_mm256_sub_epi16(signal, m_pedestal));
+}
+
+} // namespace tpglibs

--- a/src/AVXFrugalPedestalSubtractProcessor.cpp
+++ b/src/AVXFrugalPedestalSubtractProcessor.cpp
@@ -19,7 +19,7 @@ void AVXFrugalPedestalSubtractProcessor::configure(const nlohmann::json& config,
 __m256i AVXFrugalPedestalSubtractProcessor::process(const __m256i& signal) {
   // Find the channels that are above or below the pedestal.
   __m256i is_gt = _mm256_cmpgt_epi16(signal, m_pedestal);
-  __m256i is_lt = _mm256_cmpeq_epi16(m_pedestal, signal);
+  __m256i is_lt = _mm256_cmpgt_epi16(m_pedestal, signal);
 
   // Update m_accum.
   __m256i to_add = _mm256_setzero_si256();                                    // Assumes equal to pedestal.


### PR DESCRIPTION
I've added a new pedestal subtraction processor that estimates the pedestal and fixes it. The period for estimation is configurable with `start_period` and counts the number of time samples before fixing the pedestal (512 ns / tick).

I've also squashed a bug in `AVXFrugalPedestalSubtractProcessor.cpp` that resulted in a never-decreasing pedestal estimate and solves a problem we were seeing in the TP rates.

To avoid the initial garbage TPs, I've also set the starting pedestal value to the 14-bit max. The first TPs will still be nonsensical, but they will start popping up at a more controlled rate. A delayed TP sending can be implemented in `fdreadoutlibs` to fully control these bad TPs.

This was tested on a test session and reviewing the resulting TPs' ADC peak.

### Related PRs
https://github.com/DUNE-DAQ/appmodel/pull/123