### PR TITLE
Add AVX Print Utility.

### DIFF
--- a/include/tpglibs/AVXUtils.hpp
+++ b/include/tpglibs/AVXUtils.hpp
@@ -7,6 +7,10 @@
  */
 
 #include <immintrin.h>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <array>
 
 #ifndef TPGLIBS_AVXUTILS_HPP_
 #define TPGLIBS_AVXUTILS_HPP_
@@ -17,6 +21,14 @@ namespace tpglibs {
 inline __m256i _mm256_div_epi16(const __m256i& va, const int16_t& b) {
   __m256i vb = _mm256_set1_epi16(32768 / b);
   return _mm256_mulhrs_epi16(va, vb);
+}
+
+
+inline void _mm256_print_epi16(const __m256i& input) {
+  std::array<int16_t, 16> prints;
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(prints.begin()), input);
+
+  fmt::print("{}", prints);
 }
 
 } // namespace tpglibs


### PR DESCRIPTION
Printing out the AVX registers can be awkward. This introduces a utility function that prints the contents of a given register and is intended for debug usage.

Testing was done in the unit tests by printing some of the result registers.