### PR TITLE
Add TOT Conversion.

### DIFF
--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -80,6 +80,7 @@ class TPGenerator {
           for (auto tp : tps) {
             tp.time_start = (t - tp.time_over_threshold) * m_sample_tick_difference + timestamp;
             tp.time_peak  = tp.time_peak * m_sample_tick_difference + tp.time_start;
+            tp.time_over_threshold *= m_sample_tick_difference;  // Convert to the same "time" units.
             tp_aggr.push_back(tp);
           }
           cursor += register_alignment / 8; // Numerator is in bits. Need bytes.

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -66,7 +66,7 @@ AVXPipeline::generate_tps(const __m256i& tp_mask) {
     tp.adc_peak            = tp_adc_peak[i];
     tp.channel             = m_channels[i];
     tp.time_peak           = tp_time_peak[i];
-    tp.time_over_threshold = tp_tot[i];
+    tp.time_over_threshold = tp_tot[i];              // TOT was incremented by 1 in AVX. Need to convert in TPGenerator.hpp.
     tp.type                = tp.Type::kTPC;
     tp.algorithm           = tp.Algorithm::kUnknown; // TODO: Choose a separate way to represent the mixed processors.
 


### PR DESCRIPTION
AVX increments by 1, so the last step needs to scale according to the given frame's tick difference.

Testing was done by running `avx_generator_test.cxx` with the following patch and confirming that the unit test succeeds.
```
diff --git a/unittest/avx_generator_test.cxx b/unittest/avx_generator_test.cxx
index fe0c22a..b662481 100644
--- a/unittest/avx_generator_test.cxx
+++ b/unittest/avx_generator_test.cxx
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
   };
 
   TPGenerator tpg;
-  constexpr int sample_tick_difference = 1; // Arbitrary choice for this test. Live has been 32 (2024-08-15).
+  constexpr int sample_tick_difference = 32; // Arbitrary choice for this test. Live has been 32 (2024-08-15).
   tpg.configure(configs, channel_plane_numbers, sample_tick_difference);
 
   std::vector<dunedaq::trgdataformats::TriggerPrimitive> tps = tpg(&frame);
@@ -61,6 +61,10 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
 
   for (auto tp : tps) {
     if (tp.adc_peak < min_peak) min_peak = tp.adc_peak;
+    if (tp.time_over_threshold % sample_tick_difference != 0) {
+      fmt::print("TP TOT == {} != 32\n", tp.time_over_threshold);
+      BOOST_TEST(tp.time_over_threshold % sample_tick_difference == 0);
+    }
   }
 
   BOOST_TEST(tp_count == 600);
```