### PR TITLE
Use Full 32 Bits Of TP ADC Integral

### DIFF
--- a/include/tpglibs/AVXPipeline.hpp
+++ b/include/tpglibs/AVXPipeline.hpp
@@ -18,6 +18,12 @@ namespace tpglibs {
 #pragma GCC diagnostic ignored "-Wignored-attributes"
 /** @brief AVX typed TPG pipeline. */
 class AVXPipeline : public TPGPipeline<AVXProcessor, __m256i> {
+  /** @brief A vector of 1s. */
+  const __m256i m_ones_register = _mm256_set1_epi16(1);
+
+  /** @brief A vector of uint16_t max. */
+  const __m256i m_max_value_register = _mm256_set1_epi16(-1);
+
   public:
     /** @brief Save the state of the processed signals.
      *

--- a/include/tpglibs/TPGPipeline.hpp
+++ b/include/tpglibs/TPGPipeline.hpp
@@ -92,7 +92,8 @@ class TPGPipeline {
 
   protected:
     /** @brief The on-going ADC integral for channels that are considered active. */
-    signal_t m_adc_integral{};
+    signal_t m_adc_integral_lo{};
+    signal_t m_adc_integral_hi{};
     /** @brief The ADC peak for channels that are considered active. */
     signal_t m_adc_peak{};
     /** @brief The time over threshold for channels that are considered active. */

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -19,13 +19,13 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
   __m256i new_tps = _mm256_andnot_si256(was_inactive, inactive);
 
   // Get the potentially overflown integral and saturated integral.
-  __m256i adc_integral_tmp = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
+  __m256i adc_integral_over = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
   m_adc_integral_lo = _mm256_adds_epu16(m_adc_integral_lo, processed_signal);
 
   // If it is saturated, then increment the hi and reset.
   __m256i is_saturated = _mm256_cmpeq_epi16(m_adc_integral_lo, _mm256_set1_epi16(-1));
   // If lo and tmp are the same, then it is *not* saturated and happened to exactly sum to 0xFFFF.
-  __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_tmp);
+  __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_over);
   // So, (!exact) & is_saturated == [truly saturated].
   is_saturated  = _mm256_andnot_si256(exact, is_saturated);
 
@@ -35,7 +35,7 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
   // Keep the lo that is not saturated.
   __m256i keep_lo = _mm256_andnot_si256(is_saturated, m_adc_integral_lo);
   // Keep the tmp that had overflown.
-  __m256i keep_tmp = _mm256_and_si256(is_saturated, adc_integral_tmp);
+  __m256i keep_tmp = _mm256_and_si256(is_saturated, adc_integral_over);
   m_adc_integral_lo = _mm256_or_si256(keep_lo, keep_tmp);
 
   __m256i above_peak = _mm256_cmpgt_epi16(processed_signal, m_adc_peak);

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -23,13 +23,13 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
   m_adc_integral_lo = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
 
   // If it is saturated, then increment the hi. The overflown integral already "reset".
-  __m256i is_saturated = _mm256_cmpeq_epi16(adc_integral_sat, _mm256_set1_epi16(-1));
+  __m256i is_saturated = _mm256_cmpeq_epi16(adc_integral_sat, m_max_value_register);
   // If lo and sat are the same, then it is *not* saturated and happened to exactly sum to 0xFFFF.
   __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_sat);
   // So, (!exact) & is_saturated == [truly saturated].
   is_saturated  = _mm256_andnot_si256(exact, is_saturated);
 
-  __m256i to_add = _mm256_and_si256(_mm256_set1_epi16(1), is_saturated);
+  __m256i to_add = _mm256_and_si256(m_ones_register, is_saturated);
   m_adc_integral_hi = _mm256_adds_epu16(m_adc_integral_hi, to_add);
 
   __m256i above_peak = _mm256_cmpgt_epi16(processed_signal, m_adc_peak);
@@ -37,7 +37,7 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
   m_adc_peak = _mm256_max_epi16(m_adc_peak, processed_signal);
   m_time_peak = _mm256_blendv_epi8(m_time_peak, m_time_over_threshold, above_peak);
 
-  __m256i time_add = _mm256_blendv_epi8(_mm256_setzero_si256(), _mm256_set1_epi16(1), active);
+  __m256i time_add = _mm256_blendv_epi8(_mm256_setzero_si256(), m_ones_register, active);
   m_time_over_threshold = _mm256_adds_epi16(m_time_over_threshold, time_add);
 
   return new_tps;

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -24,6 +24,11 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
 
   // If it is saturated, then increment the hi and reset.
   __m256i is_saturated = _mm256_cmpeq_epi16(m_adc_integral_lo, _mm256_set1_epi16(-1));
+  // If lo and tmp are the same, then it is *not* saturated and happened to exactly sum to 0xFFFF.
+  __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_tmp);
+  // So, (!exact) & is_saturated == [truly saturated].
+  is_saturated  = _mm256_andnot_si256(exact, is_saturated);
+
   __m256i to_add = _mm256_and_si256(_mm256_set1_epi16(1), is_saturated);
   m_adc_integral_hi = _mm256_adds_epu16(m_adc_integral_hi, to_add);
 

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -18,25 +18,19 @@ AVXPipeline::save_state(const __m256i& processed_signal) {
   // If it was *not* inactive and is now inactive, then it must be a new TP.
   __m256i new_tps = _mm256_andnot_si256(was_inactive, inactive);
 
-  // Get the potentially overflown integral and saturated integral.
-  __m256i adc_integral_over = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
-  m_adc_integral_lo = _mm256_adds_epu16(m_adc_integral_lo, processed_signal);
+  // Get the potentially saturated integral and overflown integral.
+  __m256i adc_integral_sat = _mm256_adds_epu16(m_adc_integral_lo, processed_signal);
+  m_adc_integral_lo = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
 
-  // If it is saturated, then increment the hi and reset.
-  __m256i is_saturated = _mm256_cmpeq_epi16(m_adc_integral_lo, _mm256_set1_epi16(-1));
-  // If lo and tmp are the same, then it is *not* saturated and happened to exactly sum to 0xFFFF.
-  __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_over);
+  // If it is saturated, then increment the hi. The overflown integral already "reset".
+  __m256i is_saturated = _mm256_cmpeq_epi16(adc_integral_sat, _mm256_set1_epi16(-1));
+  // If lo and sat are the same, then it is *not* saturated and happened to exactly sum to 0xFFFF.
+  __m256i exact = _mm256_cmpeq_epi16(m_adc_integral_lo, adc_integral_sat);
   // So, (!exact) & is_saturated == [truly saturated].
   is_saturated  = _mm256_andnot_si256(exact, is_saturated);
 
   __m256i to_add = _mm256_and_si256(_mm256_set1_epi16(1), is_saturated);
   m_adc_integral_hi = _mm256_adds_epu16(m_adc_integral_hi, to_add);
-
-  // Keep the lo that is not saturated.
-  __m256i keep_lo = _mm256_andnot_si256(is_saturated, m_adc_integral_lo);
-  // Keep the tmp that had overflown.
-  __m256i keep_tmp = _mm256_and_si256(is_saturated, adc_integral_over);
-  m_adc_integral_lo = _mm256_or_si256(keep_lo, keep_tmp);
 
   __m256i above_peak = _mm256_cmpgt_epi16(processed_signal, m_adc_peak);
 

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -78,7 +78,7 @@ AVXPipeline::generate_tps(const __m256i& tp_mask) {
   for (int i = 0; i < 16; i++) {
     if (tp_tot[i] == 0) continue;  // Don't track non-TPs.
     dunedaq::trgdataformats::TriggerPrimitive tp;
-    tp.adc_integral        = tp_integral_lo[i] + ((uint32_t)tp_integral_hi[i] << 16);
+    tp.adc_integral        = uint32_t(tp_integral_lo[i]) + (uint32_t(tp_integral_hi[i]) << 16);
     tp.adc_peak            = tp_adc_peak[i];
     tp.channel             = m_channels[i];
     tp.time_peak           = tp_time_peak[i];

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -13,16 +13,25 @@ __m256i
 AVXPipeline::save_state(const __m256i& processed_signal) {
   __m256i active       = _mm256_cmpgt_epi16(processed_signal, _mm256_setzero_si256());
   __m256i inactive     = _mm256_cmpeq_epi16(processed_signal, _mm256_setzero_si256());
-  __m256i was_inactive = _mm256_cmpeq_epi16(m_adc_integral, _mm256_setzero_si256());
+  __m256i was_inactive = _mm256_cmpeq_epi16(m_time_over_threshold, _mm256_setzero_si256());
 
   // If it was *not* inactive and is now inactive, then it must be a new TP.
   __m256i new_tps = _mm256_andnot_si256(was_inactive, inactive);
 
-  m_adc_integral = _mm256_adds_epu16(m_adc_integral, processed_signal);
+  // Get the potentially overflown integral and saturated integral.
+  __m256i adc_integral_tmp = _mm256_add_epi16(m_adc_integral_lo, processed_signal);
+  m_adc_integral_lo = _mm256_adds_epu16(m_adc_integral_lo, processed_signal);
 
-  // If it is saturated, then we want to close early.
-  __m256i is_saturated = _mm256_cmpeq_epi16(m_adc_integral, _mm256_set1_epi16(-1));
-  new_tps = _mm256_or_si256(new_tps, is_saturated);
+  // If it is saturated, then increment the hi and reset.
+  __m256i is_saturated = _mm256_cmpeq_epi16(m_adc_integral_lo, _mm256_set1_epi16(-1));
+  __m256i to_add = _mm256_and_si256(_mm256_set1_epi16(1), is_saturated);
+  m_adc_integral_hi = _mm256_adds_epu16(m_adc_integral_hi, to_add);
+
+  // Keep the lo that is not saturated.
+  __m256i keep_lo = _mm256_andnot_si256(is_saturated, m_adc_integral_lo);
+  // Keep the tmp that had overflown.
+  __m256i keep_tmp = _mm256_and_si256(is_saturated, adc_integral_tmp);
+  m_adc_integral_lo = _mm256_or_si256(keep_lo, keep_tmp);
 
   __m256i above_peak = _mm256_cmpgt_epi16(processed_signal, m_adc_peak);
 
@@ -47,14 +56,16 @@ std::vector<dunedaq::trgdataformats::TriggerPrimitive>
 AVXPipeline::generate_tps(const __m256i& tp_mask) {
   // Mask everything that's relevant.
   __m256i time_over_threshold = _mm256_blendv_epi8(_mm256_setzero_si256(), m_time_over_threshold, tp_mask);
-  __m256i adc_integral = _mm256_blendv_epi8(_mm256_setzero_si256(), m_adc_integral, tp_mask);
+  __m256i adc_integral_lo = _mm256_blendv_epi8(_mm256_setzero_si256(), m_adc_integral_lo, tp_mask);
+  __m256i adc_integral_hi = _mm256_blendv_epi8(_mm256_setzero_si256(), m_adc_integral_hi, tp_mask);
   __m256i adc_peak = _mm256_blendv_epi8(_mm256_setzero_si256(), m_adc_peak, tp_mask);
   __m256i time_peak = _mm256_blendv_epi8(_mm256_setzero_si256(), m_time_peak, tp_mask);
 
   // Convert to uint16_t.
-  uint16_t tp_tot[16], tp_integral[16], tp_adc_peak[16], tp_time_peak[16];
+  uint16_t tp_tot[16], tp_integral_lo[16], tp_integral_hi[16], tp_adc_peak[16], tp_time_peak[16];
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_tot), time_over_threshold);
-  _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_integral), adc_integral);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_integral_lo), adc_integral_lo);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_integral_hi), adc_integral_hi);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_adc_peak), adc_peak);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(tp_time_peak), time_peak);
 
@@ -62,7 +73,7 @@ AVXPipeline::generate_tps(const __m256i& tp_mask) {
   for (int i = 0; i < 16; i++) {
     if (tp_tot[i] == 0) continue;  // Don't track non-TPs.
     dunedaq::trgdataformats::TriggerPrimitive tp;
-    tp.adc_integral        = tp_integral[i];
+    tp.adc_integral        = tp_integral_lo[i] + ((uint32_t)tp_integral_hi[i] << 16);
     tp.adc_peak            = tp_adc_peak[i];
     tp.channel             = m_channels[i];
     tp.time_peak           = tp_time_peak[i];
@@ -76,7 +87,8 @@ AVXPipeline::generate_tps(const __m256i& tp_mask) {
 
   // Reset the channels that generated tps.
   m_time_over_threshold = _mm256_blendv_epi8(m_time_over_threshold, _mm256_setzero_si256(), tp_mask);
-  m_adc_integral        = _mm256_blendv_epi8(m_adc_integral, _mm256_setzero_si256(), tp_mask);
+  m_adc_integral_lo     = _mm256_blendv_epi8(m_adc_integral_lo, _mm256_setzero_si256(), tp_mask);
+  m_adc_integral_hi     = _mm256_blendv_epi8(m_adc_integral_hi, _mm256_setzero_si256(), tp_mask);
   m_adc_peak            = _mm256_blendv_epi8(m_adc_peak, _mm256_setzero_si256(), tp_mask);
   m_time_peak           = _mm256_blendv_epi8(m_time_peak, _mm256_setzero_si256(), tp_mask);
 


### PR DESCRIPTION
The TP ADC integral field was only being used for the low 16 bits. The changes in this PR separates the AVX segment of integral calculations into the low 16 bits and high 16 bits. Then, the finalized TP combines to allow usage of the full 32 bits.

This change removes the early closing of TPs that saturate the low 16 bits, and it does **not** shift this early closing to the full 32 bits. Any channel that is saturating at 32 bits should be considered problematic as it would need to send saturated WIBEth signals (14 bit) for ~134 ms.

For testing, I applied the following patch and ran `$DBT_AREA_ROOT/build/tpglibs/unittest/avx_generator_test`:
```
diff --git a/unittest/avx_generator_test.cxx b/unittest/avx_generator_test.cxx
index fe0c22a..bec905f 100644
--- a/unittest/avx_generator_test.cxx
+++ b/unittest/avx_generator_test.cxx
@@ -26,9 +26,12 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
 
   const int num_time_samples_per_frame = dunedaq::fddetdataformats::WIBEthFrame::s_time_samples_per_frame;
 
+  uint16_t signal = 0x3333u;
+  uint16_t signal_count = 5;
   for (int t_sample = 0; t_sample < num_time_samples_per_frame; t_sample++) {
     for (int chan = 0; chan < 64; chan++) {
-      frame.set_adc(chan, t_sample, (t_sample*100 + chan) % 500);
+      uint16_t val = t_sample % (signal_count + 1) == 0 ? 0 : signal;
+      frame.set_adc(chan, t_sample, val);
     }
   }
 
@@ -44,8 +47,8 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
       "AVXThresholdProcessor",
       {
         {"plane0", 200},
-        {"plane1", 300},
-        {"plane2", 445}
+        {"plane1", 200},
+        {"plane2", 200}
       }
     }
   };
@@ -61,9 +64,11 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
 
   for (auto tp : tps) {
     if (tp.adc_peak < min_peak) min_peak = tp.adc_peak;
+    fmt::print("TP ADC Integral == {}\n", tp.adc_integral);
+    BOOST_TEST(tp.adc_integral == (uint32_t)signal * (uint32_t)signal_count);
   }
 
-  BOOST_TEST(tp_count == 600);
+//  BOOST_TEST(tp_count == 600);
   BOOST_TEST(min_peak > 200);  // Truly it should depend on the plane, so this is naive.
 }

```

To be thorough, I varied the values of `signal` and `signal_count`. For the WIBEth format, `signal` must be less than or equal to `0x3FFF` and `signal_count` must be less than 64. I tested the following cases:
* High value integrals that need the new expansion. Mixture of short signals with high values, long signals with low values, and long signals with high values.
* Low value integrals that would not need the new expansion. Mix of short signals with low values and long signals with low values.
* Integrals that are exact multiples of `0xFFFF` (`uint16_t` saturation). Set signal at `0x3333` and `signal_count` as multiples of 5.
I saw all cases succeeding with the expected integral values for each.

This was **not** tested on a live system.