### PR TITLE
Add TP Time Over Threshold Filter

### DIFF
--- a/include/tpglibs/TPGPipeline.hpp
+++ b/include/tpglibs/TPGPipeline.hpp
@@ -42,10 +42,9 @@ class TPGPipeline {
     virtual void configure(const std::vector<std::pair<std::string, nlohmann::json>> configs, const std::vector<std::pair<int16_t, int16_t>> channel_plane_numbers) {
       std::shared_ptr<processor_t> prev_processor = nullptr;
 
-      int16_t plane_numbers[16];
       for (int i = 0; i < 16; i++) {
         m_channels[i] = channel_plane_numbers[i].first;
-        plane_numbers[i] = channel_plane_numbers[i].second;
+        m_plane_numbers[i] = channel_plane_numbers[i].second;
       }
 
       for (const auto& name_config : configs) {
@@ -53,7 +52,7 @@ class TPGPipeline {
         std::shared_ptr<processor_t> processor = m_factory->create_processor(name_config.first);
 
         // Configure it.
-        processor->configure(name_config.second, plane_numbers);
+        processor->configure(name_config.second, m_plane_numbers);
 
         // If it's the first one, make it the head.
         if (!prev_processor) {
@@ -90,6 +89,14 @@ class TPGPipeline {
     /** @brief Pure virtual function that will generate TPs given a mask to draw from. */
     virtual std::vector<dunedaq::trgdataformats::TriggerPrimitive> generate_tps(const signal_t& tp_mask) = 0;
 
+    /** @brief Set the time over threshold minimum values. */
+    virtual void set_tot_minima(const std::vector<uint16_t>& tot_minima) {
+      int idx = 0;
+      for (auto tot_minimum : tot_minima) {
+        m_tot_minima[idx++] = tot_minimum;
+      }
+    }
+
   protected:
     /** @brief The on-going ADC integral for channels that are considered active. */
     signal_t m_adc_integral_lo{};
@@ -102,6 +109,10 @@ class TPGPipeline {
     signal_t m_time_peak{};
     /** @brief Detector channel numbers for the 16 channels that are being processed. */
     int16_t m_channels[16];
+    /** @brief Detector plane numbers for the 16 channels that are being processed. */
+    int16_t m_plane_numbers[16];
+    /** @brief The time over threshold minimum that a TP from plane `i` must have. */
+    uint16_t m_tot_minima[3];
     /** @brief Processor factory singleton. */
     std::shared_ptr<AbstractFactory<processor_t>> m_factory = AbstractFactory<processor_t>::get_instance();
     /** @brief Processor head to start from. */

--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -27,6 +27,7 @@ class TPGenerator {
   uint8_t m_num_pipelines = 0;  // Gets set inside configure.
   std::vector<AVXPipeline> m_tpg_pipelines;
   int m_sample_tick_difference;
+  std::vector<uint16_t> m_tot_minima{1,1,1};  // Defaults to 1 for all planes.
 
   public:
     /**
@@ -39,6 +40,13 @@ class TPGenerator {
     void configure(const std::vector<std::pair<std::string, nlohmann::json>>& configs,
                    const std::vector<std::pair<int16_t, int16_t>> channel_plane_numbers,
                    const int sample_tick_difference);
+
+    /**
+     * @brief Set the minimum time over threshold for a TP according to plane.
+     *
+     * @param tot_minima TPs from plane `i` will have at least `tot_minima[i]` value for its time_over_threshold.
+     */
+    void set_tot_minima(const std::vector<uint16_t>& tot_minima);
 
     /**
      * @brief Driving function for the TPG.

--- a/src/AVXPipeline.cpp
+++ b/src/AVXPipeline.cpp
@@ -70,7 +70,7 @@ AVXPipeline::generate_tps(const __m256i& tp_mask) {
 
   std::vector<dunedaq::trgdataformats::TriggerPrimitive> tps;
   for (int i = 0; i < 16; i++) {
-    if (tp_tot[i] == 0) continue;  // Don't track non-TPs.
+    if (tp_tot[i] < m_tot_minima[m_plane_numbers[i]]) continue;  // Don't track short TPs.
     dunedaq::trgdataformats::TriggerPrimitive tp;
     tp.adc_integral        = uint32_t(tp_integral_lo[i]) + (uint32_t(tp_integral_hi[i]) << 16);
     tp.adc_peak            = tp_adc_peak[i];

--- a/src/TPGenerator.cpp
+++ b/src/TPGenerator.cpp
@@ -22,8 +22,14 @@ TPGenerator::configure(const std::vector<std::pair<std::string, nlohmann::json>>
     auto begin_channel_plane = channel_plane_numbers.begin() + p*m_num_channels_per_pipeline;
     auto end_channel_plane = begin_channel_plane + m_num_channels_per_pipeline;
     new_pipe.configure(configs, std::vector<std::pair<int16_t, int16_t>>(begin_channel_plane, end_channel_plane));
+    new_pipe.set_tot_minima(m_tot_minima);
     m_tpg_pipelines.push_back(new_pipe);
   }
+}
+
+void
+TPGenerator::set_tot_minima(const std::vector<uint16_t>& tot_minima) {
+  m_tot_minima = tot_minima;
 }
 
 __m256i


### PR DESCRIPTION
Details in https://github.com/DUNE-DAQ/appmodel/pull/161.

The various repetitions of `16` (channels) and `3` (planes) warrants the need for a variable that defines these values and gives better context. This should be done as a separate PR.