### PR TITLE
Add TOT Minima Setting.

### DIFF
--- a/unittest/avx_pipeline_test.cxx
+++ b/unittest/avx_pipeline_test.cxx
@@ -78,7 +78,10 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
     }
   };
 
+  std::vector<uint16_t> tot_minima = {1,1,1};
+
   pipeline.configure(configs, channel_plane_numbers);
+  pipeline.set_tot_minima(tot_minima);
 
   // ADC peak should max at 1600 for all channels.
   bool adc_peak_at_1600 = true;


### PR DESCRIPTION
This was missed in PR #11. The unit test would fail before adding this setting and now passes.