### PR TITLE
Add Configurable RunSum Divisor

### DIFF
--- a/include/tpglibs/AVXRunSumProcessor.hpp
+++ b/include/tpglibs/AVXRunSumProcessor.hpp
@@ -33,6 +33,12 @@ class AVXRunSumProcessor : public AVXProcessor {
   /** @brief The `RS` in the model equation. */
   __m256i m_running_sum;
 
+  /** @brief The divisor for the `S` factor. */
+  __m256i m_scale_divisor;
+
+  /** @brief The divisor for the `R` factor. */
+  __m256i m_memory_divisor;
+
   public:
     /** @brief Calculate and store the running sum.
      *

--- a/src/AVXRunSumProcessor.cpp
+++ b/src/AVXRunSumProcessor.cpp
@@ -26,21 +26,33 @@ void AVXRunSumProcessor::configure(const nlohmann::json& config, const int16_t* 
   configure_internal_state_collection(config);
 
   int16_t memory_factors[16];
-  int16_t config_memory[3] = {config["memory_factor_plane0"],
-                              config["memory_factor_plane1"],
-                              config["memory_factor_plane2"]};
+  int16_t plane_memory_factors[3] = {config["memory_factor_plane0"],
+                                     config["memory_factor_plane1"],
+                                     config["memory_factor_plane2"]};
+  int16_t memory_divisors[16];
+  int16_t plane_memory_divisors[3] = {config["memory_divisor_plane0"],
+                                      config["memory_divisor_plane1"],
+                                      config["memory_divisor_plane2"]};
   int16_t scale_factors[16];
-  int16_t config_scale[3]  = {config["scale_factor_plane0"],
-                              config["scale_factor_plane1"],
-                              config["scale_factor_plane2"]};
+  int16_t plane_scale_factors[3]  = {config["scale_factor_plane0"],
+                                     config["scale_factor_plane1"],
+                                     config["scale_factor_plane2"]};
+  int16_t scale_divisors[16];
+  int16_t plane_scale_divisors[3] = {config["scale_divisor_plane0"],
+                                     config["scale_divisor_plane1"],
+                                     config["scale_divisor_plane2"]};
 
   for (int i = 0; i < 16; i++) {
-    memory_factors[i] = config_memory[plane_numbers[i]];
-    scale_factors[i] = config_scale[plane_numbers[i]];
+    memory_factors[i] = plane_memory_factors[plane_numbers[i]];
+    memory_divisors[i] = 0x7FFF / plane_memory_divisors[plane_numbers[i]];  // Need to adjust for AVX2 usage.
+    scale_factors[i] = plane_scale_factors[plane_numbers[i]];
+    scale_divisors[i] = 0x7FFF / plane_scale_divisors[plane_numbers[i]];  // Need to adjust for AVX2 usage.
   }
 
   m_memory_factor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(memory_factors));
+  m_memory_divisor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(memory_divisors));
   m_scale_factor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(scale_factors));
+  m_scale_divisor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(scale_divisors));
 }
 
 __m256i AVXRunSumProcessor::process(const __m256i& signal) {
@@ -50,10 +62,10 @@ __m256i AVXRunSumProcessor::process(const __m256i& signal) {
     m_internal_state_buffer_manager.write_to_active_buffer();
   }
 
-  __m256i scaled_rs = _mm256_div_epi16(m_running_sum, 10);
+  __m256i scaled_rs = _mm256_mulhrs_epi16(m_running_sum, m_memory_divisor);
   scaled_rs = _mm256_mullo_epi16(scaled_rs, m_memory_factor);
 
-  __m256i scaled_signal = _mm256_div_epi16(signal, 10);
+  __m256i scaled_signal = _mm256_mulhrs_epi16(signal, m_scale_divisor);
   scaled_signal = _mm256_mullo_epi16(scaled_signal, m_scale_factor);
 
   m_running_sum = _mm256_adds_epi16(scaled_rs, scaled_signal);

--- a/unittest/avx_factory_test.cxx
+++ b/unittest/avx_factory_test.cxx
@@ -40,7 +40,13 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
     {"memory_factor_plane2", 8},
     {"scale_factor_plane0", 5},
     {"scale_factor_plane1", 5},
-    {"scale_factor_plane2", 5}
+    {"scale_factor_plane2", 5},
+    {"memory_divisor_plane0", 10},
+    {"memory_divisor_plane1", 10},
+    {"memory_divisor_plane2", 10},
+    {"scale_divisor_plane0", 10},
+    {"scale_divisor_plane1", 10},
+    {"scale_divisor_plane2", 10}
   };
   abs_rs->configure(rs_config, plane_numbers);
   rs->configure(rs_config, plane_numbers);

--- a/unittest/avx_pipeline_test.cxx
+++ b/unittest/avx_pipeline_test.cxx
@@ -63,12 +63,18 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
     {
       "AVXRunSumProcessor",
       {
-        {"memory_factor_plane0", 10},
-        {"memory_factor_plane1", 10},
-        {"memory_factor_plane2", 10},
-        {"scale_factor_plane0", 10},
-        {"scale_factor_plane1", 10},
-        {"scale_factor_plane2", 10},
+        {"memory_factor_plane0", 1},
+        {"memory_factor_plane1", 1},
+        {"memory_factor_plane2", 1},
+        {"scale_factor_plane0", 1},
+        {"scale_factor_plane1", 1},
+        {"scale_factor_plane2", 1},
+        {"memory_divisor_plane0", 1},
+        {"memory_divisor_plane1", 1},
+        {"memory_divisor_plane2", 1},
+        {"scale_divisor_plane0", 1},
+        {"scale_divisor_plane1", 1},
+        {"scale_divisor_plane2", 1}
       }
     },
     {

--- a/unittest/avx_processors_test.cxx
+++ b/unittest/avx_processors_test.cxx
@@ -39,12 +39,18 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
   thresholds->configure(thr_config, plane_numbers);
 
   nlohmann::json rs_config = {
-    {"memory_factor_plane0", 8},
-    {"memory_factor_plane1", 8},
-    {"memory_factor_plane2", 8},
-    {"scale_factor_plane0", 5},
-    {"scale_factor_plane1", 5},
-    {"scale_factor_plane2", 5}
+    {"memory_factor_plane0", 4},
+    {"memory_factor_plane1", 4},
+    {"memory_factor_plane2", 4},
+    {"scale_factor_plane0", 1},
+    {"scale_factor_plane1", 1},
+    {"scale_factor_plane2", 1},
+    {"memory_divisor_plane0", 5},
+    {"memory_divisor_plane1", 5},
+    {"memory_divisor_plane2", 5},
+    {"scale_divisor_plane0", 2},
+    {"scale_divisor_plane1", 2},
+    {"scale_divisor_plane2", 2}
   };
   abs_rs->configure(rs_config, plane_numbers);
   rs->configure(rs_config, plane_numbers);

--- a/unittest/processor_state_registrate_collect_test.cxx
+++ b/unittest/processor_state_registrate_collect_test.cxx
@@ -87,6 +87,12 @@ BOOST_AUTO_TEST_CASE(test_avx_runsum_configuration_and_registration) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -110,6 +116,12 @@ BOOST_AUTO_TEST_CASE(test_avx_runsum_initial_state_collection) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -152,6 +164,12 @@ BOOST_AUTO_TEST_CASE(test_avx_runsum_processing_and_state_update) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -204,6 +222,12 @@ BOOST_AUTO_TEST_CASE(test_avx_abs_runsum_inherits_registration) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -227,6 +251,12 @@ BOOST_AUTO_TEST_CASE(test_avx_abs_runsum_processing_with_absolute_values) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -279,6 +309,12 @@ BOOST_AUTO_TEST_CASE(test_naive_runsum_configuration_and_registration) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -302,6 +338,12 @@ BOOST_AUTO_TEST_CASE(test_naive_runsum_initial_state_collection) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -344,6 +386,12 @@ BOOST_AUTO_TEST_CASE(test_naive_runsum_processing_and_state_update) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -492,6 +540,12 @@ BOOST_AUTO_TEST_CASE(test_naive_abs_runsum_inherits_registration) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -515,6 +569,12 @@ BOOST_AUTO_TEST_CASE(test_naive_abs_runsum_processing_with_absolute_values) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   processor->configure(config, plane_numbers);
 
@@ -670,6 +730,12 @@ BOOST_AUTO_TEST_CASE(test_all_processors_independence) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
   config["accum_limit"] = 10;
 
   // Configure each processor with its specific states
@@ -754,6 +820,12 @@ BOOST_AUTO_TEST_CASE(test_processor_chain_with_internal_states) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
 
   avx_runsum1->configure(config, plane_numbers);
   avx_runsum2->configure(config, plane_numbers);
@@ -807,6 +879,12 @@ BOOST_AUTO_TEST_CASE(test_collection_disabled) {
     {"scale_factor_plane0", 10},
     {"scale_factor_plane1", 20},
     {"scale_factor_plane2", 30},
+    {"memory_divisor_plane0", 10},
+    {"memory_divisor_plane1", 10},
+    {"memory_divisor_plane2", 10},
+    {"scale_divisor_plane0", 10},
+    {"scale_divisor_plane1", 10},
+    {"scale_divisor_plane2", 10},
     {"metric_collect_toggle_state", false}
   };
 
@@ -873,6 +951,12 @@ BOOST_AUTO_TEST_CASE(test_all_processors_core_functionality) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
   config["accum_limit"] = 10;
 
   // Configure each processor with its specific states
@@ -965,6 +1049,12 @@ BOOST_AUTO_TEST_CASE(test_processor_specific_internal_states) {
   config["scale_factor_plane0"] = 10;
   config["scale_factor_plane1"] = 20;
   config["scale_factor_plane2"] = 30;
+  config["memory_divisor_plane0"] = 10;
+  config["memory_divisor_plane1"] = 10;
+  config["memory_divisor_plane2"] = 10;
+  config["scale_divisor_plane0"] = 10;
+  config["scale_divisor_plane1"] = 10;
+  config["scale_divisor_plane2"] = 10;
   config["accum_limit"] = 10;
 
   // Configure each processor with its specific states


### PR DESCRIPTION
# Description
This PR closes #19 by adding member variables for the running sum divisors.

The changes may be tested through unit tests, integration tests, and a more detailed analysis for detector TPs (likely overkill).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Testing was done through unit tests by adding in the new divisor configs. The expected values are the same as before.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

