### PR TITLE
[Feature]: Add `TPGenerator::reset` Method

### DIFF
--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -30,9 +30,10 @@ namespace tpglibs {
  */
 class TPGenerator {
   static const uint8_t m_num_channels_per_pipeline = 16; // AVX2 with int16 data samples allows us to process 16 channels.
+  bool m_configured {false};
   uint8_t m_num_pipelines = 0;  // Gets set inside configure.
   std::vector<AVXPipeline> m_tpg_pipelines;
-  float m_sample_tick_difference;
+  float m_sample_tick_difference = 0;
   std::vector<uint16_t> m_sot_minima{1,1,1};  // Defaults to 1 for all planes.
 
   public:
@@ -46,6 +47,11 @@ class TPGenerator {
     void configure(const std::vector<std::pair<std::string, nlohmann::json>>& configs,
                    const std::vector<std::pair<dunedaq::trgdataformats::channel_t, int16_t>> channel_plane_numbers,
                    const float sample_tick_difference);
+
+    /**
+     * @brief Remove all pipelines and reset member variables to default state.
+     */
+    void reset();
 
     /**
      * @brief Set the minimum samples over threshold for a TP according to plane.

--- a/src/TPGenerator.cpp
+++ b/src/TPGenerator.cpp
@@ -14,6 +14,10 @@ void
 TPGenerator::configure(const std::vector<std::pair<std::string, nlohmann::json>>& configs,
                        const std::vector<std::pair<dunedaq::trgdataformats::channel_t, int16_t>> channel_plane_numbers,
                        const float sample_tick_difference) {
+  if (m_configured) {
+    reset();
+  }
+
   m_num_pipelines = channel_plane_numbers.size() / m_num_channels_per_pipeline;
   m_sample_tick_difference = sample_tick_difference;
 
@@ -25,20 +29,28 @@ TPGenerator::configure(const std::vector<std::pair<std::string, nlohmann::json>>
     new_pipe.set_sot_minima(m_sot_minima);
     m_tpg_pipelines.push_back(new_pipe);
   }
+
+  m_configured = true;
 }
 
 std::vector<std::pair<std::shared_ptr<AbstractProcessor<__m256i>>, int>> TPGenerator::get_all_processor_references_with_pipeline_index() {
   std::vector<std::pair<std::shared_ptr<AbstractProcessor<__m256i>>, int>> processor_references;
-  int total_pipelines = m_tpg_pipelines.size();
-  int start_index = (total_pipelines >= m_num_pipelines) ? (total_pipelines - m_num_pipelines) : 0;
-  int pipeline_id = 0;
-  for (int i = start_index; i < total_pipelines && pipeline_id < m_num_pipelines; ++i, ++pipeline_id) {
-    // @FIXME Restore to simple treatment, when repeated add of pipelines is fixed.
-    for (auto& processor : m_tpg_pipelines[i].get_all_processor_references()) {
+
+  for (int pipeline_id = 0; pipeline_id < m_num_pipelines; ++pipeline_id) {
+    for (auto& processor : m_tpg_pipelines[pipeline_id].get_all_processor_references()) {
       processor_references.push_back(std::make_pair(processor, pipeline_id));
     }
   }
   return processor_references;
+}
+
+void
+TPGenerator::reset() {
+  m_num_pipelines = 0;
+  m_tpg_pipelines.clear();
+  m_sample_tick_difference = 0;
+  m_sot_minima = {1, 1, 1};
+  m_configured = false;
 }
 
 void

--- a/unittest/avx_generator_test.cxx
+++ b/unittest/avx_generator_test.cxx
@@ -20,9 +20,8 @@
 
 namespace tpglibs {
 
-BOOST_AUTO_TEST_CASE(test_macro_overview)
-{
-  // Build a frame to send through the TPGenerator.
+/* Helper function to build a test frame to send through a TPGenerator. */
+dunedaq::fddetdataformats::WIBEthFrame create_test_frame() {
   dunedaq::fddetdataformats::WIBEthFrame frame;
 
   const int num_time_samples_per_frame = dunedaq::fddetdataformats::WIBEthFrame::s_time_samples_per_frame;
@@ -32,6 +31,15 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
       frame.set_adc(chan, t_sample, (t_sample*100 + chan) % 500);
     }
   }
+  /* Naively, this looks like:
+   *   uint14_t adcs[i][j] = (100*i + j) % 500;
+   * */
+  return frame;
+}
+
+BOOST_AUTO_TEST_CASE(test_macro_overview)
+{
+  dunedaq::fddetdataformats::WIBEthFrame frame = create_test_frame();
 
   // Lazy with the channel-plane assignments.
   std::vector<std::pair<dunedaq::trgdataformats::channel_t, int16_t>> channel_plane_numbers =
@@ -67,6 +75,52 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
 
   BOOST_TEST(tp_count == 600);
   BOOST_TEST(min_peak > 200);  // Truly it should depend on the plane, so this is naive.
+}
+
+BOOST_AUTO_TEST_CASE(test_tpg_resetting) {
+  dunedaq::fddetdataformats::WIBEthFrame frame = create_test_frame();
+
+  std::vector<std::pair<std::string, nlohmann::json>> configs = {
+    {
+      "AVXThresholdProcessor",
+      {
+        {"plane0", 200},
+        {"plane1", 300},
+        {"plane2", 445}
+      }
+    }
+  };
+
+  TPGenerator tpg;
+  constexpr int sample_tick_difference = 1;
+
+  std::vector<std::pair<dunedaq::trgdataformats::channel_t, int16_t>> channel_plane_numbers =
+          {{ 0, 0}, { 1, 0}, { 2, 0}, { 3, 0}, { 4, 0}, { 5, 0}, { 6, 0}, { 7, 0}, { 8, 0}, { 9, 0}, {10, 0}, {11, 0}, {12, 0}, {13, 0}, {14, 0}, {15, 0},
+           {16, 1}, {17, 1}, {18, 1}, {19, 1}, {20, 1}, {21, 1}, {22, 1}, {23, 1}, {24, 1}, {25, 1}, {26, 1}, {27, 1}, {28, 1}, {29, 1}, {30, 1}, {31, 1},
+           {32, 2}, {33, 2}, {34, 2}, {35, 2}, {36, 2}, {37, 2}, {38, 2}, {39, 2}, {40, 2}, {41, 2}, {42, 2}, {43, 2}, {44, 2}, {45, 2}, {46, 2}, {47, 2},
+           {48, 0}, {49, 0}, {50, 0}, {51, 0}, {52, 0}, {53, 1}, {54, 1}, {55, 1}, {56, 1}, {57, 1}, {58, 2}, {59, 2}, {60, 2}, {61, 2}, {62, 2}, {63, 2}};
+
+  tpg.configure(configs, channel_plane_numbers, sample_tick_difference);
+
+  std::vector<dunedaq::trgdataformats::TriggerPrimitive> tps = tpg(&frame);
+  BOOST_TEST(tps.size() == 600);
+
+  tps.clear();
+  tpg.reset();
+
+  configs[0].second["plane0"] = 64;
+  configs[0].second["plane1"] = 64;
+  configs[0].second["plane2"] = 64;
+
+  tpg.configure(configs, channel_plane_numbers, sample_tick_difference);
+
+  tps = tpg(&frame);
+  BOOST_TEST(tps.size() == 768);
+
+  tpg.reset();
+  tps.clear();
+  tps = tpg(&frame);
+  BOOST_TEST(tps.size() == 0);
 }
 
 } // namespace tpglibs


### PR DESCRIPTION
# Description
This PR adds a `reset` method to the `TPGenerator` class. This resets/clears all member variables that are changed as a result of the `configure` method. This allows the class to be reconfigured with any new parameters without requiring the construction of a new class.

In the case that a `TPGenerator` is attempted to be configured again while already configured, I've placed a `reset` call such that the object has a clean slate to configure on.

This PR closes #26.

Testing involved making a new unit test, running existing unit tests, running integration tests, and running a local session with the command sequence `boot`, `conf`, and `scrap` to confirm that the `TPGenerator` was reset. However, this identified an issue outlined in https://github.com/DUNE-DAQ/datahandlinglibs/issues/110.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

