### PR TITLE
Introduces TPGLIBS_ENABLE_STATE_MONITORING CMake option (OFF by defau…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ find_package(daq-cmake REQUIRED)
 
 daq_setup_environment()
 
+option(TPGLIBS_ENABLE_STATE_MONITORING "Enable TPG internal state monitoring" OFF)
+
 find_package(fmt REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(detdataformats REQUIRED)
@@ -25,16 +27,22 @@ endif()
 
 daq_add_library( *.cpp  LINK_LIBRARIES nlohmann_json::nlohmann_json detdataformats::detdataformats fddetdataformats::fddetdataformats trgdataformats::trgdataformats fmt::fmt )
 
+if(TPGLIBS_ENABLE_STATE_MONITORING)
+  target_compile_definitions(tpglibs PUBLIC TPGLIBS_ENABLE_STATE_MONITORING)
+endif()
+
 daq_add_python_bindings(*.cpp)
 
 daq_add_unit_test(avx_factory_test LINK_LIBRARIES tpglibs)
 daq_add_unit_test(avx_generator_test LINK_LIBRARIES tpglibs)
 daq_add_unit_test(avx_pipeline_test LINK_LIBRARIES tpglibs)
 daq_add_unit_test(avx_processors_test LINK_LIBRARIES tpglibs)
-daq_add_unit_test(ProcessorInternalStateNameRegistry_test LINK_LIBRARIES tpglibs)
-daq_add_unit_test(ProcessorInternalStateBufferManager_test LINK_LIBRARIES tpglibs)
-daq_add_unit_test(avx_processors_internal_state_collect_test LINK_LIBRARIES tpglibs)
-daq_add_unit_test(processor_state_registrate_collect_test LINK_LIBRARIES tpglibs)
+if(TPGLIBS_ENABLE_STATE_MONITORING)
+  daq_add_unit_test(ProcessorInternalStateNameRegistry_test LINK_LIBRARIES tpglibs)
+  daq_add_unit_test(ProcessorInternalStateBufferManager_test LINK_LIBRARIES tpglibs)
+  daq_add_unit_test(avx_processors_internal_state_collect_test LINK_LIBRARIES tpglibs)
+  daq_add_unit_test(processor_state_registrate_collect_test LINK_LIBRARIES tpglibs)
+endif()
 daq_add_unit_test(binary_signal_reader_test LINK_LIBRARIES tpglibs)
 
 # Add test application

--- a/cmake/tpglibsConfig.cmake.in
+++ b/cmake/tpglibsConfig.cmake.in
@@ -1,6 +1,8 @@
 
 @PACKAGE_INIT@
 
+set(TPGLIBS_ENABLE_STATE_MONITORING @TPGLIBS_ENABLE_STATE_MONITORING@)
+
 include(CMakeFindDependencyMacro)
 
 # Insert find_dependency() calls for your package's dependencies in

--- a/include/tpglibs/AbstractProcessor.hpp
+++ b/include/tpglibs/AbstractProcessor.hpp
@@ -14,8 +14,10 @@
 #include <memory>
 
 #include "tpglibs/ProcessorMetricArray.hpp"
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
 #include "tpglibs/ProcessorInternalStateBufferManager.hpp"
 #include "tpglibs/ProcessorInternalStateNameRegistry.hpp"
+#endif
 
 namespace tpglibs {
 
@@ -29,6 +31,7 @@ class AbstractProcessor {
   std::shared_ptr<AbstractProcessor<T>> m_next_processor;
 
   protected:
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
     ProcessorInternalStateBufferManager<T> m_internal_state_buffer_manager;
     ProcessorInternalStateNameRegistry<T> m_internal_state_name_registry;
     
@@ -36,6 +39,7 @@ class AbstractProcessor {
     std::atomic<uint64_t> m_samples{0};
     bool m_collect_internal_state_flag{false};
     uint64_t m_sample_period{1};
+#endif
 
   public:
     /** @brief Signal type to process on. General __m256i. */
@@ -43,6 +47,7 @@ class AbstractProcessor {
 
     virtual ~AbstractProcessor() = default;
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
     ProcessorInternalStateBufferManager<T>* _get_internal_state_buffer_manager() {
       return &m_internal_state_buffer_manager;
     }
@@ -78,6 +83,10 @@ class AbstractProcessor {
         }
       }
     }
+#else
+    /** @brief No-op: state monitoring disabled at build time. */
+    virtual void configure_internal_state_collection(const nlohmann::json& /* config */) {}
+#endif
 
     /** @brief Pure virtual function that will configure the processor using plane numbers. */
     virtual void configure(const nlohmann::json& config, const int16_t* plane_numbers) = 0;
@@ -102,11 +111,19 @@ class AbstractProcessor {
 
     /** @brief Get the names of requested internal states (delegates to registry). */
     virtual std::vector<std::string> get_requested_internal_state_names() const {
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
       return m_internal_state_name_registry.get_names_of_requested_internal_states();
+#else
+      return {};
+#endif
     }
 
     virtual ProcessorMetricArray<std::array<int16_t, 16>> read_internal_states_as_integer_array() {
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
       return m_internal_state_buffer_manager.switch_buffer_and_read_casted();
+#else
+      return {nullptr, 0};
+#endif
     }
 };
 

--- a/src/AVXFrugalPedestalSubtractProcessor.cpp
+++ b/src/AVXFrugalPedestalSubtractProcessor.cpp
@@ -13,25 +13,24 @@ namespace tpglibs {
 REGISTER_AVXPROCESSOR_CREATOR("AVXFrugalPedestalSubtractProcessor", AVXFrugalPedestalSubtractProcessor)
 
 void AVXFrugalPedestalSubtractProcessor::configure(const nlohmann::json& config, const int16_t* /* plane_numbers */) {
-  // Configure common metric collection parameters
-  // Register pointers to the ACTUAL member variables, not copies
-  // Use shared_ptr with no-op deleter to avoid double-free
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_internal_state_name_registry.register_internal_state("pedestal", 
     std::shared_ptr<__m256i>(&m_pedestal, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("accum", 
     std::shared_ptr<__m256i>(&m_accum, [](auto*){}));
-    
   configure_internal_state_collection(config);
+#endif
   
   m_accum_limit = config["accum_limit"];
 }
 
 __m256i AVXFrugalPedestalSubtractProcessor::process(const __m256i& signal) {
-  // Update sample counter and write internal states to buffer for harvesting
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_samples++;
   if (m_collect_internal_state_flag && (m_samples % m_sample_period == 0)) {
     m_internal_state_buffer_manager.write_to_active_buffer();
   }
+#endif
 
   // Find the channels that are above or below the pedestal.
   __m256i is_gt = _mm256_cmpgt_epi16(signal, m_pedestal);

--- a/src/AVXRunSumProcessor.cpp
+++ b/src/AVXRunSumProcessor.cpp
@@ -13,17 +13,15 @@ namespace tpglibs {
 REGISTER_AVXPROCESSOR_CREATOR("AVXRunSumProcessor", AVXRunSumProcessor)
 
 void AVXRunSumProcessor::configure(const nlohmann::json& config, const int16_t* plane_numbers) {
-  // Configure common metric collection parameters
-  // Register pointers to the ACTUAL member variables, not copies
-  // Use shared_ptr with no-op deleter to avoid double-free
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_internal_state_name_registry.register_internal_state("r", 
     std::shared_ptr<__m256i>(&m_memory_factor, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("s", 
     std::shared_ptr<__m256i>(&m_scale_factor, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("rs", 
     std::shared_ptr<__m256i>(&m_running_sum, [](auto*){}));
-    
   configure_internal_state_collection(config);
+#endif
 
   int16_t memory_factors[16];
   int16_t plane_memory_factors[3] = {config["memory_factor_plane0"],
@@ -56,11 +54,12 @@ void AVXRunSumProcessor::configure(const nlohmann::json& config, const int16_t* 
 }
 
 __m256i AVXRunSumProcessor::process(const __m256i& signal) {
-  // Update sample counter and write internal states to buffer for harvesting
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_samples++;
   if (m_collect_internal_state_flag && (m_samples % m_sample_period == 0)) {
     m_internal_state_buffer_manager.write_to_active_buffer();
   }
+#endif
 
   __m256i scaled_rs = _mm256_mulhrs_epi16(m_running_sum, m_memory_divisor);
   scaled_rs = _mm256_mullo_epi16(scaled_rs, m_memory_factor);

--- a/src/NaiveFrugalPedestalSubtractProcessor.cpp
+++ b/src/NaiveFrugalPedestalSubtractProcessor.cpp
@@ -13,26 +13,25 @@ namespace tpglibs {
 REGISTER_NAIVEPROCESSOR_CREATOR("NaiveFrugalPedestalSubtractProcessor", NaiveFrugalPedestalSubtractProcessor)
 
 void NaiveFrugalPedestalSubtractProcessor::configure(const nlohmann::json& config, const int16_t* plane_numbers) {
-  // Configure common metric collection parameters
-  // Register pointers to the ACTUAL member variables, not copies
-  // Use shared_ptr with no-op deleter to avoid double-free
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_internal_state_name_registry.register_internal_state("pedestal", 
     std::shared_ptr<naive_array_t>(&m_pedestal, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("accum", 
     std::shared_ptr<naive_array_t>(&m_accum, [](auto*){}));
-    
   configure_internal_state_collection(config);
+#endif
   
   m_accum_limit = config["accum_limit"];
 }
 
 NaiveFrugalPedestalSubtractProcessor::naive_array_t
 NaiveFrugalPedestalSubtractProcessor::process(const naive_array_t& signal) {
-  // Update sample counter and write internal states to buffer for harvesting
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_samples++;
   if (m_collect_internal_state_flag && (m_samples % m_sample_period == 0)) {
     m_internal_state_buffer_manager.write_to_active_buffer();
   }
+#endif
 
   naive_array_t subtracted_signal;
   for (int i = 0; i < 16; i++) {

--- a/src/NaiveRunSumProcessor.cpp
+++ b/src/NaiveRunSumProcessor.cpp
@@ -13,17 +13,15 @@ namespace tpglibs {
 REGISTER_NAIVEPROCESSOR_CREATOR("NaiveRunSumProcessor", NaiveRunSumProcessor)
 
 void NaiveRunSumProcessor::configure(const nlohmann::json& config, const int16_t* plane_numbers) {
-  // Configure common metric collection parameters
-  // Register pointers to the ACTUAL member variables, not copies
-  // Use shared_ptr with no-op deleter to avoid double-free
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_internal_state_name_registry.register_internal_state("r", 
     std::shared_ptr<naive_array_t>(&m_memory_factor, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("s", 
     std::shared_ptr<naive_array_t>(&m_scale_factor, [](auto*){}));
   m_internal_state_name_registry.register_internal_state("rs", 
     std::shared_ptr<naive_array_t>(&m_running_sum, [](auto*){}));
-    
   configure_internal_state_collection(config);
+#endif
 
   int16_t config_memory[3] = {config["memory_factor_plane0"],
                               config["memory_factor_plane1"],
@@ -39,11 +37,12 @@ void NaiveRunSumProcessor::configure(const nlohmann::json& config, const int16_t
 }
 
 NaiveRunSumProcessor::naive_array_t NaiveRunSumProcessor::process(const naive_array_t& signal) {
-  // Update sample counter and write internal states to buffer for harvesting
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   m_samples++;
   if (m_collect_internal_state_flag && (m_samples % m_sample_period == 0)) {
     m_internal_state_buffer_manager.write_to_active_buffer();
   }
+#endif
 
   for (int i = 0; i < 16; i++) {
     int32_t scaled_rs = _naive_div_int16(m_running_sum[i], 10);

--- a/unittest/ProcessorInternalStateBufferManager_test.cxx
+++ b/unittest/ProcessorInternalStateBufferManager_test.cxx
@@ -6,6 +6,8 @@
  * received with this code.
  */
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+
 #define BOOST_TEST_MODULE ProcessorInternalStateBufferManager_tests
 #define FMT_HEADER_ONLY
 
@@ -626,3 +628,5 @@ BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace tpglibs
  
+
+#endif // TPGLIBS_ENABLE_STATE_MONITORING

--- a/unittest/ProcessorInternalStateNameRegistry_test.cxx
+++ b/unittest/ProcessorInternalStateNameRegistry_test.cxx
@@ -8,6 +8,8 @@
  * received with this code.
  */
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+
 #define BOOST_TEST_MODULE ProcessorInternalStateNameRegistry_test
 #define FMT_HEADER_ONLY
 #define TPGLIBS_ENABLE_TEST_INTERFACES
@@ -856,3 +858,5 @@ BOOST_AUTO_TEST_CASE(test_memory_leak_scenario)
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace tpglibs
+
+#endif // TPGLIBS_ENABLE_STATE_MONITORING

--- a/unittest/avx_processors_internal_state_collect_test.cxx
+++ b/unittest/avx_processors_internal_state_collect_test.cxx
@@ -8,6 +8,8 @@
  * received with this code.
  */
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+
 #define BOOST_TEST_MODULE AVXProcessorInternalStateCollectionTest
 #define FMT_HEADER_ONLY
 
@@ -1012,3 +1014,5 @@ BOOST_AUTO_TEST_CASE(test_multiple_allocations) {
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace tpglibs
+
+#endif // TPGLIBS_ENABLE_STATE_MONITORING

--- a/unittest/processor_state_registrate_collect_test.cxx
+++ b/unittest/processor_state_registrate_collect_test.cxx
@@ -9,6 +9,8 @@
  * received with this code.
  */
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+
 #define BOOST_TEST_MODULE ProcessorStateRegistrationCollectionTest
 #define FMT_HEADER_ONLY
 
@@ -1104,3 +1106,5 @@ BOOST_AUTO_TEST_CASE(test_processor_specific_internal_states) {
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace tpglibs
+
+#endif // TPGLIBS_ENABLE_STATE_MONITORING


### PR DESCRIPTION
Gates the *ProcessorInternalState* infrastructure via #ifdef. Monitoring, process checking, registration, and unit-tests are excluded from code level when off.

# Description

See issue #39 for details
Addresses issue #39 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`) (tpg_state_collection test fails due to new ERS warning unexpected. Will be fixed.
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Test in progress.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

