### PR TITLE
Fix cpplint issue currently in the library.

### DIFF
--- a/include/tpglibs/AbstractFactory.hxx
+++ b/include/tpglibs/AbstractFactory.hxx
@@ -30,7 +30,6 @@ void AbstractFactory<T>::register_creator(const std::string& processor_name, cre
     return;
   }
   throw std::runtime_error("Attempted to overwrite a creator in factory with " + processor_name);
-  return;
 }
 
 template <typename T>
@@ -43,7 +42,6 @@ std::shared_ptr<T> AbstractFactory<T>::create_processor(const std::string& proce
   }
 
   throw std::runtime_error("Factory failed to find " + processor_name);
-  return nullptr;
 }
 
 template <typename T>

--- a/include/tpglibs/TPGPipeline.hpp
+++ b/include/tpglibs/TPGPipeline.hpp
@@ -16,6 +16,7 @@
 #include "trgdataformats/Types.hpp"
 
 #include <nlohmann/json.hpp>
+#include <array>
 #include <vector>
 
 namespace tpglibs {
@@ -45,8 +46,8 @@ class TPGPipeline {
       std::shared_ptr<processor_t> prev_processor = nullptr;
 
       for (int i = 0; i < 16; i++) {
-        m_channels[i] = channel_plane_numbers[i].first;
-        m_plane_numbers[i] = channel_plane_numbers[i].second;
+        m_channels.at(i) = channel_plane_numbers[i].first;
+        m_plane_numbers.at(i) = channel_plane_numbers[i].second;
       }
 
       for (const auto& name_config : configs) {
@@ -54,7 +55,7 @@ class TPGPipeline {
         std::shared_ptr<processor_t> processor = m_factory->create_processor(name_config.first);
 
         // Configure it.
-        processor->configure(name_config.second, m_plane_numbers);
+        processor->configure(name_config.second, m_plane_numbers.data());
 
         // If it's the first one, make it the head.
         if (!prev_processor) {
@@ -112,7 +113,7 @@ class TPGPipeline {
     virtual void set_sot_minima(const std::vector<uint16_t>& sot_minima) {
       int idx = 0;
       for (auto sot_minimum : sot_minima) {
-        m_sot_minima[idx++] = sot_minimum;
+        m_sot_minima.at(idx++) = sot_minimum;
       }
     }
 
@@ -127,11 +128,11 @@ class TPGPipeline {
     /** @brief The number of samples from `time_start` to the ADC peak. */
     signal_t m_samples_to_peak{};
     /** @brief Detector channel numbers for the 16 channels that are being processed. */
-    dunedaq::trgdataformats::channel_t m_channels[16];
+    std::array<dunedaq::trgdataformats::channel_t, 16> m_channels;
     /** @brief Detector plane numbers for the 16 channels that are being processed. */
-    int16_t m_plane_numbers[16];
+    std::array<int16_t, 16> m_plane_numbers;
     /** @brief The samples over threshold minimum that a TP from plane `i` must have. */
-    uint16_t m_sot_minima[3];
+    std::array<uint16_t, 3> m_sot_minima;
     /** @brief Processor factory singleton. */
     std::shared_ptr<AbstractFactory<processor_t>> m_factory = AbstractFactory<processor_t>::get_instance();
     /** @brief Processor head to start from. */

--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -91,7 +91,7 @@ class TPGenerator {
       // Loop in time.
       for (int t = 0; t < T::s_time_samples_per_frame; t++) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        const typename T::word_t *time_sample = words_base + static_cast<std::ptrdiff_t>(t) * row_stride;
+        const typename T::word_t *time_sample = words_base + t * row_stride;
         const char* cursor = reinterpret_cast<const char*>(time_sample); // Need to walk in terms of bytes/bits.
 
         // Loop in pipelines.

--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -90,13 +90,17 @@ class TPGenerator {
       const int register_alignment = T::s_bits_per_adc * m_num_channels_per_pipeline;
       // Loop in time.
       for (int t = 0; t < T::s_time_samples_per_frame; t++) {
-        const typename T::word_t *time_sample = words_base + static_cast<std::ptrdiff_t>(t) * row_stride;  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const typename T::word_t *time_sample = words_base + static_cast<std::ptrdiff_t>(t) * row_stride;
         const char* cursor = reinterpret_cast<const char*>(time_sample); // Need to walk in terms of bytes/bits.
 
         // Loop in pipelines.
         for (int p = 0; p < m_num_pipelines; p++) {
-          if (p == m_num_pipelines - 1)
-            cursor -= 4; // Take a step of 32 bit backwards for the last sub-frame.  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          if (p == m_num_pipelines - 1) {
+            // Take a step of 32 bit backwards for the last sub-frame.
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            cursor -= 4;
+          }
 
           __m256i regi = _mm256_lddqu_si256(reinterpret_cast<const __m256i*>(cursor));
 
@@ -107,10 +111,13 @@ class TPGenerator {
           std::vector<dunedaq::trgdataformats::TriggerPrimitive> tps = m_tpg_pipelines[p].process(expanded_subframe);
 
           for (auto tp : tps) {
-            tp.time_start = static_cast<int64_t>(static_cast<float>(t - tp.samples_over_threshold) * m_sample_tick_difference) + timestamp;
+            const auto offset_samples = static_cast<float>(t - tp.samples_over_threshold);
+            tp.time_start =
+                static_cast<int64_t>(offset_samples * m_sample_tick_difference) + timestamp;
             tp_aggr.push_back(tp);
           }
-          cursor += register_alignment / 8; // Numerator is in bits. Need bytes.  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          cursor += register_alignment / 8; // Numerator is in bits. Need bytes.
         }
       }
 

--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -82,21 +82,23 @@ class TPGenerator {
       std::vector<dunedaq::trgdataformats::TriggerPrimitive> tp_aggr;
       tp_aggr.reserve(T::s_num_channels * T::s_time_samples_per_frame / 2);
 
-      const typename T::word_t (*words_ptr)[T::s_bits_per_adc] = frame->adc_words;
+      // Flatten the external 2-D C-array to a 1-D base pointer; traversal by row stride.
+      const typename T::word_t* const words_base = &frame->adc_words[0][0];
+      constexpr int row_stride = T::s_bits_per_adc;
       const uint64_t timestamp = frame->get_timestamp();
 
       const int register_alignment = T::s_bits_per_adc * m_num_channels_per_pipeline;
       // Loop in time.
       for (int t = 0; t < T::s_time_samples_per_frame; t++) {
-        const typename T::word_t *time_sample = *(words_ptr + t);
-        char* cursor = (char*) time_sample; // Need to walk in terms of bytes/bits.
+        const typename T::word_t *time_sample = words_base + static_cast<std::ptrdiff_t>(t) * row_stride;  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const char* cursor = reinterpret_cast<const char*>(time_sample); // Need to walk in terms of bytes/bits.
 
         // Loop in pipelines.
         for (int p = 0; p < m_num_pipelines; p++) {
           if (p == m_num_pipelines - 1)
-            cursor -= 4; // Take a step of 32 bit backwards for the last sub-frame.
+            cursor -= 4; // Take a step of 32 bit backwards for the last sub-frame.  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
-          __m256i regi = _mm256_lddqu_si256((__m256i*)cursor);
+          __m256i regi = _mm256_lddqu_si256(reinterpret_cast<const __m256i*>(cursor));
 
           if (p == m_num_pipelines - 1) // Permute the row order to use the same operation.
             regi = _mm256_permutevar8x32_epi32(regi, _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 0));
@@ -105,10 +107,10 @@ class TPGenerator {
           std::vector<dunedaq::trgdataformats::TriggerPrimitive> tps = m_tpg_pipelines[p].process(expanded_subframe);
 
           for (auto tp : tps) {
-            tp.time_start = static_cast<int64_t>((t - tp.samples_over_threshold) * m_sample_tick_difference) + timestamp;
+            tp.time_start = static_cast<int64_t>(static_cast<float>(t - tp.samples_over_threshold) * m_sample_tick_difference) + timestamp;
             tp_aggr.push_back(tp);
           }
-          cursor += register_alignment / 8; // Numerator is in bits. Need bytes.
+          cursor += register_alignment / 8; // Numerator is in bits. Need bytes.  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         }
       }
 


### PR DESCRIPTION
# Description

At the moment, CI workflow of development related to `tpglibs` suffers from a few lint errors from historical code (most likely an update on the CI / lint side?)

https://github.com/DUNE-DAQ/fdreadoutlibs/actions/runs/24704435009/job/72256956991?pr=290

This PR is an attempt to address these existing issues without changing code behaviour.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

I don't believe detector testing in needed on this one. Careful code review is prefered.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

