### PR TITLE
JCF: DUNE-DAQ/daq-deliverables#215: update the code to account for me…

### DIFF
--- a/include/tpglibs/TPGenerator.hpp
+++ b/include/tpglibs/TPGenerator.hpp
@@ -83,7 +83,7 @@ class TPGenerator {
       tp_aggr.reserve(T::s_num_channels * T::s_time_samples_per_frame / 2);
 
       // Flatten the external 2-D C-array to a 1-D base pointer; traversal by row stride.
-      const typename T::word_t* const words_base = &frame->adc_words[0][0];
+      const typename T::word_t* const words_base = frame->get_adc_words();
       constexpr int row_stride = T::s_bits_per_adc;
       const uint64_t timestamp = frame->get_timestamp();
 


### PR DESCRIPTION
…mber data being defaulted to private on the johnfreeman/daq-deliverables_issue215_fddetdataformats_improvements branch of fddetdataformats

# Description

This is a very simple one line change, but one which is only to be merged after the merging of `fddetdataformats`' https://github.com/DUNE-DAQ/fddetdataformats/pull/58 PR. It updates the code to reflect the fact that member data in frames is made `private` in that PR.  

Testing would essentially be, does the code build? It should be done in concert with the testing of the other repos which have branches with the `johnfreeman/daq-deliverables_issue215_fddetdataformats_improvements` name (`fddetdataformats`, obviously, but also `crtmodules` and `fdreadoutlibs`). 



## Type of change
This is a bug fix in the sense that, once the `fddetdataformats` PR is merged in, the code on the `develop` branch of this repo will be broken until this PR is merged in. 

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

